### PR TITLE
Move builtins to /builtins

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -6,7 +6,7 @@ on:
       container_tag:
         description: "Container tag"
         required: false
-        default: "latest"
+        default: "${{ github.ref }}"
       update_fluence:
         description: Whether to update fluence.json
         required: false

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -7,15 +7,19 @@ on:
         description: "Container tag"
         required: false
         default: "latest"
+      update_fluence:
+        description: Whether to update fluence.json
+        required: false
+        default: "false"
       version:
         description: 'Fluence version'
-        required: true
+        required: false
       url:
         description: 'Fluence binary URL'
-        required: true
+        required: false
       sha256:
         description: 'Fluence binary SHA256 hash'
-        required: true
+        required: false
 
 jobs:
   build-publish:
@@ -23,11 +27,13 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CONTAINER_TAG: ${{ github.event.inputs.container_tag || 'latest' }}
+      UPDATE_FLUENCE: ${{ github.event.inputs.update_fluence == 'true' || github.event.inputs.container_tag == ''  }}
       
     steps:
       - uses: actions/checkout@v2
 
       - name: Update Fluence in fluence.json to ${{ github.event.inputs.version }}
+        if: ${{ env.UPDATE_FLUENCE }}
         run: |
           echo '
           {

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -6,7 +6,7 @@ on:
       container_tag:
         description: "Container tag"
         required: false
-        default: "${{ github.ref }}"
+        default: ${{ github.ref }}
       update_fluence:
         description: Whether to update fluence.json
         required: false

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -6,7 +6,7 @@ on:
       container_tag:
         description: "Container tag"
         required: false
-        default: ${{ github.ref }}
+        default: "latest"
       update_fluence:
         description: Whether to update fluence.json
         required: false

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -69,6 +69,7 @@ jobs:
           TAG="${{ env.CONTAINER_TAG }}"
           RUN="${{ github.run_number }}"
           TAGS=fluencelabs/node:${TAG},fluencelabs/node:${TAG}_v${RUN}
+          TAGS=$TAGS,fluencelabs/fluence:${TAG},fluencelabs/fluence:${TAG}_v${RUN}
           
           echo "TAGS=$TAGS" | tee -a $GITHUB_ENV
           echo "BUILD_DATE=$(date '+%Y-%m-%dT%H:%M:%S%:z')"

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Update Fluence in fluence.json to ${{ github.event.inputs.version }}
-        if: ${{ env.UPDATE_FLUENCE !== 'false' }}
+        if: ${{ env.UPDATE_FLUENCE != 'false' }}
         run: |
           echo '
           {

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Update Fluence in fluence.json to ${{ github.event.inputs.version }}
-        if: ${{ env.UPDATE_FLUENCE }}
+        if: ${{ env.UPDATE_FLUENCE !== 'false' }}
         run: |
           echo '
           {

--- a/fluence/Config.default.toml
+++ b/fluence/Config.default.toml
@@ -22,7 +22,7 @@ autodeploy_particle_ttl = "60s"
 # default is /.fluence/v1/certificates
 # certificate_dir = "./certificates"
 ## directory for builtins
-# default is /builtins
+# default is /.fluence/v1/builtins
 # builtins_base_dir = "./builtins"
 
 ## Path to AIR interpreter .wasm is set to specific version by default

--- a/fluence/deploy/Config.toml
+++ b/fluence/deploy/Config.toml
@@ -1,3 +1,6 @@
+autodeploy_particle_ttl = "60s"
+builtins_base_dir = "/builtins"
+
 [root_key_pair]
 format = "ed25519"
 path = "/node.key"
@@ -5,8 +8,6 @@ path = "/node.key"
 [builtins_key_pair]
 format = "ed25519"
 generate_on_absence = true
-
-autodeploy_particle_ttl = "60s"
 
 [root_weights]
 12D3KooWDMWjFq1QZG5szbQRbyQ1A8wyrEJSQaFXwMyqkFeLoHTt = 3

--- a/fluence/deploy/deployment_config.json
+++ b/fluence/deploy/deployment_config.json
@@ -1,10 +1,10 @@
 {
-  "target": "krasnodar",
+  "target": "stage",
 
   "environments": [
     {
       "name": "krasnodar",
-      "container_tag": "latest_v233",
+      "container_tag": "update_air_v255",
       "containers_per_host": 1,
       "external_bootstraps": [
         "/ip4/165.227.164.206/tcp/7001",
@@ -69,7 +69,7 @@
     },
     {
       "name": "testnet",
-      "container_tag": "latest_v233",
+      "container_tag": "update_air_v255",
       "containers_per_host": 1,
       "external_bootstraps": [],
       "hosts": [

--- a/fluence/deploy/deployment_config.json
+++ b/fluence/deploy/deployment_config.json
@@ -4,7 +4,7 @@
   "environments": [
     {
       "name": "krasnodar",
-      "container_tag": "update_air_v255",
+      "container_tag": "latest_v259",
       "containers_per_host": 1,
       "external_bootstraps": [
         "/ip4/165.227.164.206/tcp/7001",
@@ -69,7 +69,7 @@
     },
     {
       "name": "testnet",
-      "container_tag": "update_air_v255",
+      "container_tag": "latest_v259",
       "containers_per_host": 1,
       "external_bootstraps": [],
       "hosts": [
@@ -130,7 +130,7 @@
     },
     {
       "name": "stage",
-      "container_tag": "latest_v233",
+      "container_tag": "latest_v259",
       "containers_per_host": 5,
       "hosts": [
         "134.209.186.43"

--- a/fluence/download_builtins.sh
+++ b/fluence/download_builtins.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -o pipefail -o errexit -o nounset
 
-BUILTINS_DIR=/.fluence/v1/builtins/
+BUILTINS_DIR=/builtins/
 TMP_BUILTINS=./tmp/builtins
 
 mkdir -p $BUILTINS_DIR


### PR DESCRIPTION
Before this PR, builtin services were downloaded to `/.fluence/v1/builtins`. Since `/.fluence` is in the volume, that means that builtins were never updated on deploy.

This PR moves builtin services to directory `/builtins` so that they are embedded in the docker image and updated together with the image.