### PR TITLE
Config.default.toml: builtins_base_dir = "/builtins"

### DIFF
--- a/fluence/run_fluence
+++ b/fluence/run_fluence
@@ -5,4 +5,4 @@
 # see https://github.com/fluencelabs/node-distro/issues/14 for more details
 unexport HOME
 # 'setuidgid abc' runs '/fluence' as user 'abc'
-s6-setuidgid abc /fluence -c /.fluence/v1/Config.toml $@
+s6-setuidgid abc /fluence $@


### PR DESCRIPTION
Previously default config was ignored and the default builtins directory was not set