### PR TITLE
Remove aqua-ipfs builtin in minimal image

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Currently provides Network Dashboard as a side-car.
 
 | Container flavor | IPFS daemon | services                         | binaries                                   |
 | ---------------- | ----------- | -------------------------------- | ------------------------------------------ |
-| minimal          | ❌           | aqua-ipfs, trust-graph, registry | curl                                       |
+| minimal          | ❌           | trust-graph, registry            | curl                                       |
 | ipfs             | ✅           | aqua-ipfs, trust-graph, registry | curl, ipfs                                 |
 | rich             | ✅           | aqua-ipfs, trust-graph, registry | curl, ipfs, ceramic, bitcoin cli, geth cli |
 

--- a/s6/minimal/etc/cont-init.d/40-aqua-ipfs
+++ b/s6/minimal/etc/cont-init.d/40-aqua-ipfs
@@ -1,0 +1,6 @@
+#!/usr/bin/with-contenv bash
+
+if ! command -v ipfs; then
+  echo "IPFS binary not present, removing aqua-ipfs builtin"
+  rm -rf /builtins/aqua-ipfs
+fi


### PR DESCRIPTION
aqua-ipfs won't start without IPFS binary

It will be a better idea to add IPFS binary to minimal image but not start IPFS daemon.