### PR TITLE
chore: Use ubuntu 22.04 as base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN tar -xzf "bitcoin-${BITCOIN_CLI_VERSION}-x86_64-linux-gnu.tar.gz"
 
 # minimal
 # ----------------------------------------------------------------------------
-FROM ghcr.io/linuxserver/baseimage-ubuntu:focal as minimal
+FROM ghcr.io/linuxserver/baseimage-ubuntu:jammy as minimal
 
 # https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys
 LABEL org.opencontainers.image.created="${BUILD_DATE}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,8 @@ COPY --from=prepare-ipfs /usr/local/bin/ipfs /usr/bin/ipfs
 # copy s6 configs
 COPY s6/minimal/ /
 
+CMD ["--local"]
+
 # ipfs
 # ----------------------------------------------------------------------------
 FROM minimal as ipfs

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,8 +77,6 @@ COPY --from=prepare-ipfs /usr/local/bin/ipfs /usr/bin/ipfs
 # copy s6 configs
 COPY s6/minimal/ /
 
-CMD ["--local"]
-
 # ipfs
 # ----------------------------------------------------------------------------
 FROM minimal as ipfs

--- a/s6/minimal/run_fluence
+++ b/s6/minimal/run_fluence
@@ -7,5 +7,6 @@ with-contenv
 # remove old HOME variable from the environment, so the daemon isn't confused by it
 # see https://github.com/fluencelabs/node-distro/issues/14 for more details
 unexport HOME
+
 # 'setuidgid abc' runs '/usr/bin/fluence' as user 'abc'
 s6-setuidgid abc /usr/bin/fluence $@

--- a/s6/minimal/run_fluence
+++ b/s6/minimal/run_fluence
@@ -7,6 +7,5 @@ with-contenv
 # remove old HOME variable from the environment, so the daemon isn't confused by it
 # see https://github.com/fluencelabs/node-distro/issues/14 for more details
 unexport HOME
-
 # 'setuidgid abc' runs '/usr/bin/fluence' as user 'abc'
 s6-setuidgid abc /usr/bin/fluence $@


### PR DESCRIPTION
- rust-peer is built on ubuntu 22.04 now with new GLIBC version update to base image required